### PR TITLE
feat: add project tooling configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv/
 bdcn_repo/
 models/
+results/
+.coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-flake8
+    rev: v6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: [--config-file=setup.cfg]

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,17 @@ scikit-image>=0.18.0
 # Development / Testing (optional)
 pytest>=6.0.0
 jupyter>=1.0.0
+
+# Development Tools
+black
+flake8
+isort
+mypy
+pytest
+pytest-cov
+opencv-python-stubs
+streamlit
+types-requests
+types-Pillow
+pre-commit
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,41 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,E266,E402,E701,E731,E722,E741,E265,W503,E121
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    venv
+
+[mypy]
+ignore_missing_imports = True
+follow_imports = silent
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+check_untyped_defs = False
+no_implicit_optional = False
+warn_unused_ignores = True
+
+[isort]
+profile = black
+multi_line_output = 3
+line_length = 88
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+
+[tool:pytest]
+addopts = -ra -q --tb=short
+testpaths = tests
+
+[coverage:run]
+branch = True
+source =
+    detectors
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.: 
+    if typing.TYPE_CHECKING:

--- a/tools/check_all.sh
+++ b/tools/check_all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "✅ Linting mit flake8"
+flake8 .
+
+echo "✅ Formatieren mit black"
+black .
+
+echo "✅ Sortieren mit isort"
+isort .
+
+echo "✅ Typprüfung mit mypy"
+mypy .
+
+echo "✅ Tests mit pytest"
+pytest --cov=detectors

--- a/validate_environment.py
+++ b/validate_environment.py
@@ -1,0 +1,15 @@
+import sys
+import platform
+
+def validate_environment():
+    """Sicherstellen, dass Umgebung den Anforderungen entspricht."""
+    assert sys.version_info >= (3, 10), "Python 3.10+ erforderlich"
+    assert platform.system() == "Windows", "Windows-Umgebung erforderlich"
+    assert platform.release() in ["10", "11"], "Windows 10/11 erforderlich"
+
+if __name__ == "__main__":
+    try:
+        validate_environment()
+        print("Environment OK")
+    except AssertionError as e:
+        print(f"Environment check failed: {e}")


### PR DESCRIPTION
## Summary
- add flake8/mypy/isort/pytest/coverage config in `setup.cfg`
- configure pre-commit hooks
- append dev tool requirements
- add convenience script `tools/check_all.sh`
- ignore coverage files

## Testing
- `flake8 .` *(fails: F401, E221, E501, etc.)*
- `mypy detectors.py` *(fails: Name "re" is not defined, etc.)*
- `pytest -q --cov=detectors` *(fails: No data was collected)*
- `python run_edge_detectors.py --input_dir images --output_dir temp_results` *(fails: ModuleNotFoundError: No module named 'torch')*
- `timeout 10 streamlit run streamlit_app.py --headless --server.port 8888` *(fails: No such option: --headless)*


------
https://chatgpt.com/codex/tasks/task_e_68491eb9f2488327b22b1b060113ea0a